### PR TITLE
Don't use frame.symbol_address() 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,7 +146,7 @@ where
                 let l = locker.lock();
                 // On win7 64, it's may cause deadlock, solution is to palce a newer version of dbghelp.dll combined with exe
                 backtrace::trace_unsynchronized(|frame| {
-                    let symbol_address = frame.symbol_address();
+                    let symbol_address = frame.ip();
                     v.push(symbol_address as usize).is_ok()
                 });
                 drop(l);


### PR DESCRIPTION
because on linux it returns a pointer to the address.
This does not play well with resolve_unsynchronized() which subtracts 1 from the pointer
because normally the IP is 1 ahead of the actual location and it want to point to the correct line.
On OSX and Windows, symbols_address() just calls ip() so this calls ip() directly, fixing linux.